### PR TITLE
bisq-mobile compatibility

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,39 @@
+plugins {
+    java
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+allprojects {
+    plugins.apply("java")
+    // Configure Java toolchain for Java 17
+    tasks.withType<JavaCompile> {
+        sourceCompatibility = "17"
+        targetCompatibility = "17"
+    }
+
+    // Alternatively, use the toolchain configuration
+    extensions.configure<JavaPluginExtension> {
+        toolchain {
+            languageVersion.set(JavaLanguageVersion.of(17))
+        }
+    }
+}
+
+tasks.named("clean") {
+    dependsOn(subprojects.map { it.tasks.named("clean") })
+}
+
+tasks.named("build") {
+    dependsOn(subprojects.map { it.tasks.named("build") })
+}
+
 extensions.findByName("buildScan")?.withGroovyBuilder {
     setProperty("termsOfServiceUrl", "https://gradle.com/terms-of-service")
     setProperty("termsOfServiceAgree", "yes")


### PR DESCRIPTION
 - added necessary declarations to ensure java17 bytecode needed for jars export in bisq-mobile
 - handy clean / build subproject connection