### PR TITLE
Set targetCompatibility to Java 11.

### DIFF
--- a/build-logic/commons/src/main/kotlin/bisq.java-conventions.gradle.kts
+++ b/build-logic/commons/src/main/kotlin/bisq.java-conventions.gradle.kts
@@ -13,6 +13,8 @@ java {
     toolchain {
         languageVersion.set(JavaLanguageVersion.of(11))
     }
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 }
 
 tasks {


### PR DESCRIPTION
New devs have reported that they could not get Bisq 2 running without having Java 11 installed. I cannot verify that this is really required, but by setting the sourceCompatibility and targetCompatibility to Java 11 this should help to avoid that issue.