### PR TITLE
Normalize bitcoind archive outputs

### DIFF
--- a/build-logic/commons/src/main/kotlin/bisq.java-conventions.gradle.kts
+++ b/build-logic/commons/src/main/kotlin/bisq.java-conventions.gradle.kts
@@ -1,4 +1,5 @@
 import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.api.tasks.bundling.AbstractArchiveTask
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 
 plugins {
@@ -26,6 +27,11 @@ tasks {
     test {
         useJUnitPlatform()
     }
+}
+
+tasks.withType<AbstractArchiveTask>().configureEach {
+    isPreserveFileTimestamps = false
+    isReproducibleFileOrder = true
 }
 
 val versionCatalog = extensions.getByType<VersionCatalogsExtension>().named("libs")


### PR DESCRIPTION
Configure bitcoind archive tasks to omit file timestamps and use reproducible file ordering so jars from clean rebuilds do not differ only by ZIP metadata.

Verification:

```bash
./gradlew :bitcoind:bitcoind:jar --stacktrace
git -C bitcoind diff --check
```